### PR TITLE
hiding catch in prelude and deprecating required base version

### DIFF
--- a/Codec/Audio/Vorbis/File.hsc
+++ b/Codec/Audio/Vorbis/File.hsc
@@ -36,7 +36,7 @@ import Data.Int
 import Data.Typeable
 import Foreign hiding (new)
 import Foreign.C
-import Prelude hiding (read)
+import Prelude hiding (catch, read)
 import System.IO (SeekMode(..), hClose, hSeek, hTell, IOMode(..))
 import qualified System.IO as IO
 import System.Endian

--- a/libvorbis.cabal
+++ b/libvorbis.cabal
@@ -73,7 +73,7 @@ source-repository head
 library
   exposed-modules:     Codec.Audio.Vorbis.File
   -- other-modules:       
-  build-depends:       base >= 4.6.0.0 && < 4.8.0.0,
+  build-depends:       base >= 4.5.0.0 && < 4.8.0.0,
                        bytestring >= 0.10.0.0,
                        cpu >= 0.1.1
   include-dirs:        libogg-1.3.1/include, libvorbis-1.3.3/include, libvorbis-1.3.3/lib


### PR DESCRIPTION
In trying to get the sodium-2d-game-engine working on ubuntu 12.04 with ghc 7.4.1 I was able to overcome the build issues by making this minor tweaks.
