### PR TITLE
Bump base upper bound.

### DIFF
--- a/libvorbis.cabal
+++ b/libvorbis.cabal
@@ -73,7 +73,7 @@ source-repository head
 library
   exposed-modules:     Codec.Audio.Vorbis.File
   -- other-modules:       
-  build-depends:       base >= 4.5.0.0 && < 4.9.0.0,
+  build-depends:       base >= 4.5.0.0 && < 5.0.0.0,
                        bytestring >= 0.10.0.0,
                        cpu >= 0.1.1
   include-dirs:        libogg-1.3.1/include, libvorbis-1.3.3/include, libvorbis-1.3.3/lib


### PR DESCRIPTION
Right now you can't use this with most projects due to the base upper bound being too low. I bumped it to 5.